### PR TITLE
Update AndroidManifest.xml

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -11,6 +11,8 @@
             android:exported="true"
             android:launchMode="singleTop"
             android:theme="@style/LaunchTheme"
+            // for android 13
+            android:enableOnBackInvokedCallback="false"
             android:configChanges="orientation|keyboardHidden|keyboard|screenSize|smallestScreenSize|locale|layoutDirection|fontScale|screenLayout|density|uiMode"
             android:hardwareAccelerated="true"
             android:windowSoftInputMode="adjustResize">


### PR DESCRIPTION
Our Android app targeting API level 33 (Android 13) unexpectedly terminates when the system back button is pressed, despite implementing WillPopScope in Flutter. The issue likely arises from the default-enabled OnBackInvokedCallback in Android 13, which overrides traditional back navigation handling. To resolve this, we recommend adding android:enableOnBackInvokedCallback="false" to the <activity> tag in the AndroidManifest.xml. This change should disable the new callback mechanism and allow WillPopScope to function as intended. We are seeking further guidance or a fix in future platform updates.